### PR TITLE
fix(deps): use new name for Google's release please action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: jimeh/release-please-manifest-action@v1
+      # TOOD: Switch back to @v1 once once v1.0.3 is released.
+      - uses: jimeh/release-please-manifest-action@main
         id: release
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}

--- a/action.yml
+++ b/action.yml
@@ -133,7 +133,7 @@ runs:
         APP_TOKEN: "${{ steps.github-app-token.outputs.token }}"
         INPUT_TOKEN: "${{ inputs.token }}"
       shell: bash
-    - uses: google-github-actions/release-please-action@v3
+    - uses: googleapis/release-please-action@v3
       id: release-please
       with:
         command: manifest


### PR DESCRIPTION
Google have moved their `release-please-action` repository from the
`google-github-actions` org to the `googleapis` org.

This annoyingly seems to have broken all GitHub Actions and workflows that
refers to `google-github-actions/release-please-action`.